### PR TITLE
feat(about,cv): tech stack marquee + canonical ul/li skill lists

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,6 +50,24 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+  --animate-marquee: marquee var(--duration) infinite linear;
+  --animate-marquee-vertical: marquee-vertical var(--duration) linear infinite;
+  @keyframes marquee {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(calc(-100% - var(--gap)));
+    }
+  }
+  @keyframes marquee-vertical {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(calc(-100% - var(--gap)));
+    }
+  }
 }
 
 :root {
@@ -143,7 +161,12 @@
     overflow-x: clip;
     min-height: 100dvh;
   }
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-family: var(--font-heading);
     letter-spacing: -0.02em;
   }
@@ -173,7 +196,9 @@
   font-weight: 600;
   box-shadow: 0 10px 30px rgb(0 0 0 / 0.15);
   transform: translateY(-150%);
-  transition: transform 150ms ease, box-shadow 150ms ease;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease;
 }
 
 .skip-link:focus-visible,
@@ -263,7 +288,8 @@
     break-inside: avoid;
   }
 
-  p, li {
+  p,
+  li {
     orphans: 3;
     widows: 3;
   }

--- a/src/components/cv/cv-skills.tsx
+++ b/src/components/cv/cv-skills.tsx
@@ -27,16 +27,16 @@ export async function CvSkills({ skills, locale, className }: CvSkillsProps) {
               <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1 print:text-[9pt]">
                 {categoryName}
               </h3>
-              <div className="flex flex-wrap gap-1.5">
+              <ul className="flex flex-wrap gap-1.5 list-none p-0 m-0">
                 {category.skills.map((skill) => (
-                  <span
+                  <li
                     key={skill.name}
                     className="inline-block px-2 py-0.5 text-xs rounded-md bg-muted text-foreground print:text-[8pt] print:bg-transparent print:border print:border-border print:px-1"
                   >
                     {skill.name}
-                  </span>
+                  </li>
                 ))}
-              </div>
+              </ul>
             </div>
           );
         })}

--- a/src/components/cv/themes/portfolio-gallery.tsx
+++ b/src/components/cv/themes/portfolio-gallery.tsx
@@ -165,13 +165,15 @@ export async function PortfolioGalleryTheme({ data, locale }: PortfolioGalleryPr
                       </ul>
                     )}
                     {entry.tags && entry.tags.length > 0 && (
-                      <div className="mt-2 flex flex-wrap gap-1.5">
+                      <ul className="mt-2 flex flex-wrap gap-1.5 list-none p-0">
                         {entry.tags.map((tag) => (
-                          <Badge key={tag} variant="secondary" className="text-[0.65rem] px-2 py-0 bg-gallery-warm/10 text-foreground hover:bg-gallery-warm/20">
-                            {tag}
-                          </Badge>
+                          <li key={tag}>
+                            <Badge variant="secondary" className="text-[0.65rem] px-2 py-0 bg-gallery-warm/10 text-foreground hover:bg-gallery-warm/20">
+                              {tag}
+                            </Badge>
+                          </li>
                         ))}
-                      </div>
+                      </ul>
                     )}
                   </article>
                 ))}
@@ -242,13 +244,15 @@ export async function PortfolioGalleryTheme({ data, locale }: PortfolioGalleryPr
                 {data.skills.map((group) => (
                   <div key={r(group.category)}>
                     <p className="text-xs font-medium text-muted-foreground mb-2">{r(group.category)}</p>
-                    <div className="flex flex-wrap gap-1.5">
+                    <ul className="flex flex-wrap gap-1.5 list-none p-0 m-0">
                       {group.skills.map((skill) => (
-                        <Badge key={skill.name} variant="secondary" className="rounded-full px-2.5 py-0.5 text-xs font-medium bg-gallery-warm/15 text-foreground hover:bg-gallery-warm/25 dark:bg-gallery-warm/10 dark:text-foreground dark:hover:bg-gallery-warm/20 transition-colors">
-                          {skill.name}
-                        </Badge>
+                        <li key={skill.name}>
+                          <Badge variant="secondary" className="rounded-full px-2.5 py-0.5 text-xs font-medium bg-gallery-warm/15 text-foreground hover:bg-gallery-warm/25 dark:bg-gallery-warm/10 dark:text-foreground dark:hover:bg-gallery-warm/20 transition-colors">
+                            {skill.name}
+                          </Badge>
+                        </li>
                       ))}
-                    </div>
+                    </ul>
                   </div>
                 ))}
               </div>
@@ -275,13 +279,15 @@ export async function PortfolioGalleryTheme({ data, locale }: PortfolioGalleryPr
                 <h2 className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground mb-4">
                   <Puzzle className="h-4 w-4" /> {t("softSkills")}
                 </h2>
-                <div className="flex flex-wrap gap-1.5">
+                <ul className="flex flex-wrap gap-1.5 list-none p-0 m-0">
                   {(data.softSkills[locale as keyof typeof data.softSkills] as string[] || data.softSkills.en).map((skill: string) => (
-                    <Badge key={skill} variant="outline" className="rounded-2xl text-xs h-auto max-w-full whitespace-normal break-words py-1 leading-snug">
-                      {skill}
-                    </Badge>
+                    <li key={skill}>
+                      <Badge variant="outline" className="rounded-2xl text-xs h-auto max-w-full whitespace-normal break-words py-1 leading-snug">
+                        {skill}
+                      </Badge>
+                    </li>
                   ))}
-                </div>
+                </ul>
               </section>
             )}
 

--- a/src/components/sections/about-section.tsx
+++ b/src/components/sections/about-section.tsx
@@ -3,7 +3,7 @@
 import { useTranslations, useLocale } from "next-intl";
 import { Briefcase, Brain, Globe, GraduationCap } from "lucide-react";
 import { SectionHeading } from "@/components/shared/section-heading";
-import { TechBadge } from "@/components/shared/tech-badge";
+import { TechMarquee } from "@/components/shared/tech-marquee";
 import { DifferentiatorCard } from "@/components/cards/differentiator-card";
 import { TimelineEntryCard } from "@/components/cards/timeline-entry";
 import { timelineData } from "@/content/timeline";
@@ -70,26 +70,18 @@ export function AboutSection({ downloadCvEnabled }: AboutSectionProps) {
         </div>
       </div>
 
-      <div>
+      <div data-section="tech-stack">
         <h3 className="text-sm font-medium uppercase tracking-widest text-muted-foreground mb-6">
           {t("techStack")}
         </h3>
         <div className="space-y-6">
-          {techStackData.map((group) => (
-            <div key={group.label}>
-              <p className="text-xs font-medium text-muted-foreground mb-2">
-                {group.label}
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {group.skills.map((skill) => (
-                  <TechBadge
-                    key={skill.name}
-                    name={skill.name}
-                    category={skill.category}
-                  />
-                ))}
-              </div>
-            </div>
+          {techStackData.map((group, i) => (
+            <TechMarquee
+              key={group.label}
+              group={group}
+              index={i}
+              isRtl={locale === "ar"}
+            />
           ))}
         </div>
       </div>

--- a/src/components/shared/tech-marquee.tsx
+++ b/src/components/shared/tech-marquee.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { TechBadge } from "@/components/shared/tech-badge";
+import type { TechCategory, TechSkill } from "@/content/tech-stack";
+import { cn } from "@/lib/utils";
+
+interface TechMarqueeProps {
+  group: TechCategory;
+  index: number;
+  isRtl?: boolean;
+  className?: string;
+}
+
+/**
+ * Gap between badges within a marquee row (must match the Tailwind
+ * `[--gap:0.5rem]` utility applied on the marquee container).
+ */
+const GAP_PX = 8;
+
+/**
+ * Safety margin subtracted from the container width when computing the
+ * greedy row-pack, so the edge fade mask has visual breathing room.
+ */
+const EDGE_SAFETY_PX = 24;
+
+/**
+ * SSR-safe layout effect: uses `useLayoutEffect` on the client to avoid
+ * a flash from the 1-row SSR fallback to the measured N-row layout, and
+ * falls back to `useEffect` on the server where neither would actually
+ * run anyway.
+ */
+const useIsoLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+interface MarqueeRowProps {
+  skills: TechSkill[];
+  reverse: boolean;
+  duration: number;
+  subRowIndex: number;
+}
+
+function MarqueeRow({ skills, reverse, duration, subRowIndex }: MarqueeRowProps) {
+  const renderTrack = (ariaHidden: boolean, trackKey: string) => (
+    <ul
+      key={trackKey}
+      aria-hidden={ariaHidden || undefined}
+      className={cn(
+        "flex shrink-0 items-center gap-(--gap) list-none p-0 m-0 py-1",
+        "animate-marquee",
+        reverse && "[animation-direction:reverse]",
+        // Pause the whole category on desktop mouse hover (group is on the
+        // <section> ancestor) and on mobile touch-hold (data-touch-active on
+        // the same section, toggled by React touch handlers).
+        "group-hover:[animation-play-state:paused]",
+        "group-data-[touch-active=true]:[animation-play-state:paused]",
+      )}
+    >
+      {skills.map((skill) => (
+        <li key={skill.name} className="shrink-0">
+          <TechBadge name={skill.name} category={skill.category} />
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div
+      data-subrow={subRowIndex}
+      className={cn(
+        "relative flex gap-(--gap) overflow-hidden",
+        "[--gap:0.5rem]",
+        "[mask-image:linear-gradient(to_right,transparent,black_6%,black_94%,transparent)]",
+        "[-webkit-mask-image:linear-gradient(to_right,transparent,black_6%,black_94%,transparent)]",
+      )}
+      style={{ "--duration": `${duration}s` } as React.CSSProperties}
+    >
+      {renderTrack(false, "primary")}
+      {renderTrack(true, "dup-1")}
+      {renderTrack(true, "dup-2")}
+    </div>
+  );
+}
+
+/**
+ * Infinite-scrolling marquee row for one tech-stack category.
+ *
+ * Design notes:
+ * - SSR default renders a single row containing all skills — matches the
+ *   hydrated first-paint and gives crawlers / no-JS users the canonical list.
+ * - After mount, a client-side measurement step reads the natural width of
+ *   every badge in the primary `<ul>` (widths are cached in a ref) and
+ *   greedy-packs the skill list into as many sub-rows as needed so that
+ *   every badge is visible on initial paint at the current viewport.
+ * - A `ResizeObserver` re-runs the pack on container resize.
+ * - The primary `<ul>` in each sub-row is the canonical list (read by
+ *   crawlers, LLM scrapers, screen readers). The two duplicate tracks exist
+ *   only for the seamless CSS loop and are marked `aria-hidden`.
+ * - Scroll direction alternates per sub-row (even = forward, odd = reverse).
+ *   In RTL locales the pattern is inverted so row 0 still "flows forward"
+ *   relative to the reader. Sub-rows within the same category continue the
+ *   same alternation so multi-row categories get a zigzag motion feel.
+ * - Duration scales with each sub-row's own skill count so perceived speed
+ *   stays similar across short and long rows.
+ * - Pause-on-interaction is scoped to the whole category via Tailwind
+ *   `group` on the <section>: hovering anywhere in the category (desktop
+ *   mouse) pauses every sub-row in that category; touching-and-holding
+ *   anywhere in the category (mobile) does the same via the
+ *   `data-touch-active` attribute toggled by React touch handlers. Other
+ *   categories keep scrolling throughout.
+ * - The global `prefers-reduced-motion: reduce` rule in globals.css stops
+ *   all animations, so no per-row override is needed here.
+ */
+export function TechMarquee({
+  group,
+  index,
+  isRtl = false,
+  className,
+}: TechMarqueeProps) {
+  // Base direction for the category (alternates by category index).
+  const baseReverse = isRtl ? index % 2 === 0 : index % 2 === 1;
+
+  // SSR default: one sub-row containing all skills. This also matches the
+  // first client render, which is what the measurement step reads from.
+  const [rows, setRows] = useState<TechSkill[][]>(() => [group.skills]);
+
+  // Mobile touch-hold pause: true while a finger is down inside the section.
+  const [touched, setTouched] = useState(false);
+  const releaseTouch = () => setTouched(false);
+
+  const containerRef = useRef<HTMLElement>(null);
+  const cachedWidthsRef = useRef<number[] | null>(null);
+
+  useIsoLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const measureAndSplit = () => {
+      // 1. Ensure we have cached per-skill widths. On first run the primary
+      //    <ul> still holds every skill (SSR shape), so we measure from it.
+      if (
+        cachedWidthsRef.current === null ||
+        cachedWidthsRef.current.length !== group.skills.length
+      ) {
+        const primary = container.querySelector<HTMLUListElement>(
+          "ul:not([aria-hidden])",
+        );
+        if (!primary) return;
+        const items = primary.querySelectorAll<HTMLLIElement>("li");
+        if (items.length !== group.skills.length) return;
+        const widths = Array.from(items).map(
+          (li) => li.getBoundingClientRect().width,
+        );
+        if (widths.some((w) => !Number.isFinite(w) || w <= 0)) return;
+        cachedWidthsRef.current = widths;
+      }
+
+      // 2. Greedy-pack using cached widths and current container width.
+      const containerWidth = container.clientWidth;
+      if (containerWidth <= 0) return;
+      const maxRowWidth = Math.max(containerWidth - EDGE_SAFETY_PX, 0);
+      const widths = cachedWidthsRef.current;
+      const packed: TechSkill[][] = [[]];
+      let used = 0;
+      group.skills.forEach((skill, i) => {
+        const needed = widths[i] + GAP_PX;
+        const currentRow = packed[packed.length - 1];
+        if (currentRow.length > 0 && used + needed > maxRowWidth) {
+          packed.push([]);
+          used = 0;
+        }
+        packed[packed.length - 1].push(skill);
+        used += needed;
+      });
+
+      // 3. Update state only when the shape actually changes, to avoid
+      //    triggering an unnecessary re-render loop under ResizeObserver.
+      setRows((prev) => (sameShape(prev, packed) ? prev : packed));
+    };
+
+    measureAndSplit();
+
+    const ro = new ResizeObserver(() => measureAndSplit());
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [group.skills]);
+
+  const labelId = `tech-marquee-label-${group.category}`;
+
+  return (
+    <section
+      ref={containerRef}
+      aria-labelledby={labelId}
+      className={cn(
+        "tech-marquee-row group touch-manipulation",
+        className,
+      )}
+      data-touch-active={touched || undefined}
+      onTouchStart={() => setTouched(true)}
+      onTouchEnd={releaseTouch}
+      onTouchCancel={releaseTouch}
+    >
+      <p
+        id={labelId}
+        className="text-xs font-medium text-muted-foreground mb-2"
+      >
+        {group.label}
+      </p>
+
+      <div className="space-y-2">
+        {rows.map((rowSkills, subIdx) => {
+          // Alternate direction per sub-row, starting from the category's
+          // base direction. Example (LTR, category index 0): sub-row 0 →,
+          // sub-row 1 ←, sub-row 2 →.
+          const rowReverse = subIdx % 2 === 0 ? baseReverse : !baseReverse;
+          const duration = Math.max(30, Math.round(rowSkills.length * 3.5));
+          return (
+            <MarqueeRow
+              key={subIdx}
+              subRowIndex={subIdx}
+              skills={rowSkills}
+              reverse={rowReverse}
+              duration={duration}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function sameShape(a: TechSkill[][], b: TechSkill[][]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].length !== b[i].length) return false;
+    for (let j = 0; j < a[i].length; j++) {
+      if (a[i][j].name !== b[i][j].name) return false;
+    }
+  }
+  return true;
+}

--- a/src/components/ui/marquee.tsx
+++ b/src/components/ui/marquee.tsx
@@ -1,0 +1,74 @@
+import { type ComponentPropsWithoutRef } from "react"
+
+import { cn } from "@/lib/utils"
+
+interface MarqueeProps extends ComponentPropsWithoutRef<"div"> {
+  /**
+   * Optional CSS class name to apply custom styles
+   */
+  className?: string
+  /**
+   * Whether to reverse the animation direction
+   * @default false
+   */
+  reverse?: boolean
+  /**
+   * Whether to pause the animation on hover
+   * @default false
+   */
+  pauseOnHover?: boolean
+  /**
+   * Content to be displayed in the marquee
+   */
+  children: React.ReactNode
+  /**
+   * Whether to animate vertically instead of horizontally
+   * @default false
+   */
+  vertical?: boolean
+  /**
+   * Number of times to repeat the content
+   * @default 4
+   */
+  repeat?: number
+}
+
+export function Marquee({
+  className,
+  reverse = false,
+  pauseOnHover = false,
+  children,
+  vertical = false,
+  repeat = 4,
+  ...props
+}: MarqueeProps) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "group flex gap-(--gap) overflow-hidden p-2 [--duration:40s] [--gap:1rem]",
+        {
+          "flex-row": !vertical,
+          "flex-col": vertical,
+        },
+        className
+      )}
+    >
+      {Array(repeat)
+        .fill(0)
+        .map((_, i) => (
+          <div
+            key={i}
+            className={cn("flex shrink-0 justify-around gap-(--gap)", {
+              "animate-marquee flex-row": !vertical,
+              "animate-marquee-vertical flex-col": vertical,
+              "group-hover:[animation-play-state:paused]": pauseOnHover,
+              "[animation-direction:reverse]": reverse,
+            })}
+          >
+            {children}
+          </div>
+        ))}
+    </div>
+  )
+}

--- a/tests/e2e/tech-stack.spec.ts
+++ b/tests/e2e/tech-stack.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Tech Stack — Homepage marquee", () => {
+  test("renders 6 category sections", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+    const rows = page.locator("section.tech-marquee-row");
+    await expect(rows).toHaveCount(6);
+  });
+
+  test("each category has a primary <ul> + at least one aria-hidden duplicate per sub-row", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+    const rows = page.locator("section.tech-marquee-row");
+    const count = await rows.count();
+    for (let i = 0; i < count; i++) {
+      const row = rows.nth(i);
+      const primaries = row.locator("ul:not([aria-hidden])");
+      const dupes = row.locator('ul[aria-hidden="true"]');
+      const primaryCount = await primaries.count();
+      const dupeCount = await dupes.count();
+      expect(primaryCount).toBeGreaterThanOrEqual(1);
+      // 2 aria-hidden duplicates per sub-row
+      expect(dupeCount).toBe(primaryCount * 2);
+    }
+  });
+
+  test("at 1440px: long categories (AI/ML, Frameworks) split into >= 2 sub-rows, short ones stay at 1", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+
+    // Category #1 is AI / Machine Learning (21 skills), #2 is Frameworks (25).
+    const aiRow = page.locator("section.tech-marquee-row").nth(1);
+    const frameworksRow = page.locator("section.tech-marquee-row").nth(2);
+    // Short categories
+    const dbRow = page.locator("section.tech-marquee-row").nth(4); // Databases (4)
+    const toolsRow = page.locator("section.tech-marquee-row").nth(5); // Tools (6)
+
+    const aiSubrows = await aiRow.locator("[data-subrow]").count();
+    const fwSubrows = await frameworksRow.locator("[data-subrow]").count();
+    const dbSubrows = await dbRow.locator("[data-subrow]").count();
+    const toolsSubrows = await toolsRow.locator("[data-subrow]").count();
+
+    expect(aiSubrows).toBeGreaterThanOrEqual(2);
+    expect(fwSubrows).toBeGreaterThanOrEqual(2);
+    expect(dbSubrows).toBe(1);
+    expect(toolsSubrows).toBe(1);
+  });
+
+  test("every skill from tech-stack.ts appears at least once in the DOM (no lost items)", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+
+    // Spot-check some known long-category skills that would otherwise be
+    // hidden off-screen on the first paint.
+    const section = page.locator('[data-section="tech-stack"]');
+    const text = await section.innerText();
+    // AI/ML tail-end skills (previously queued behind the scroll):
+    expect(text).toMatch(/\bStatistical Modeling\b/);
+    expect(text).toMatch(/\bTime Series\b/);
+    // Frameworks tail-end:
+    expect(text).toMatch(/\bSeaborn\b/);
+    // Short-category items still present:
+    expect(text).toMatch(/\bJupyter\b/);
+  });
+
+  test("sub-rows alternate animation direction within a multi-row category", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+
+    const aiRow = page.locator("section.tech-marquee-row").nth(1);
+    const primaries = aiRow.locator("ul:not([aria-hidden])");
+    const n = await primaries.count();
+    expect(n).toBeGreaterThanOrEqual(2);
+    const cls0 = (await primaries.nth(0).getAttribute("class")) ?? "";
+    const cls1 = (await primaries.nth(1).getAttribute("class")) ?? "";
+    const rev0 = cls0.includes("[animation-direction:reverse]");
+    const rev1 = cls1.includes("[animation-direction:reverse]");
+    expect(rev0).not.toBe(rev1);
+  });
+
+  test("hovering any sub-row pauses every sub-row of that category; other categories keep running", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+
+    const rows = page.locator("section.tech-marquee-row");
+    // Pick AI/ML (index 1) because it's guaranteed to be multi-row at 1440px.
+    const targetCategory = rows.nth(1);
+    const otherCategory = rows.nth(2);
+
+    // Hover only the FIRST sub-row inside AI/ML.
+    const firstSubrow = targetCategory.locator("[data-subrow]").first();
+    await firstSubrow.hover();
+    await page.waitForTimeout(150);
+
+    // EVERY animate-marquee track inside the hovered category must be paused,
+    // including the tracks of sub-rows we did not directly hover.
+    const targetStates = await targetCategory
+      .locator("ul.animate-marquee")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).animationPlayState));
+    expect(targetStates.length).toBeGreaterThan(0);
+    targetStates.forEach((s) => expect(s).toBe("paused"));
+
+    // Every track in a different category must still be running.
+    const otherStates = await otherCategory
+      .locator("ul.animate-marquee")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).animationPlayState));
+    expect(otherStates.length).toBeGreaterThan(0);
+    otherStates.forEach((s) => expect(s).toBe("running"));
+  });
+
+  test("touch-hold on a category pauses its tracks; releasing resumes them", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+
+    const rows = page.locator("section.tech-marquee-row");
+    const targetCategory = rows.nth(1); // AI/ML
+    const otherCategory = rows.nth(2); // Frameworks
+
+    // Baseline: all tracks running.
+    const before = await targetCategory
+      .locator("ul.animate-marquee")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).animationPlayState));
+    before.forEach((s) => expect(s).toBe("running"));
+
+    // Synthesise a touchstart inside the category's <section>.
+    await targetCategory.dispatchEvent("touchstart", {
+      bubbles: true,
+      cancelable: true,
+      touches: [{ identifier: 1, clientX: 100, clientY: 100 }],
+      targetTouches: [{ identifier: 1, clientX: 100, clientY: 100 }],
+      changedTouches: [{ identifier: 1, clientX: 100, clientY: 100 }],
+    });
+    await page.waitForTimeout(80);
+
+    const paused = await targetCategory
+      .locator("ul.animate-marquee")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).animationPlayState));
+    paused.forEach((s) => expect(s).toBe("paused"));
+
+    // Other categories unaffected.
+    const otherDuringTouch = await otherCategory
+      .locator("ul.animate-marquee")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).animationPlayState));
+    otherDuringTouch.forEach((s) => expect(s).toBe("running"));
+
+    // Release the touch.
+    await targetCategory.dispatchEvent("touchend", {
+      bubbles: true,
+      cancelable: true,
+      touches: [],
+      targetTouches: [],
+      changedTouches: [{ identifier: 1, clientX: 100, clientY: 100 }],
+    });
+    await page.waitForTimeout(80);
+
+    const after = await targetCategory
+      .locator("ul.animate-marquee")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).animationPlayState));
+    after.forEach((s) => expect(s).toBe("running"));
+  });
+
+  test("respects prefers-reduced-motion", async ({ browser }) => {
+    const context = await browser.newContext({
+      reducedMotion: "reduce",
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    await page.goto("/en");
+    const track = page
+      .locator("section.tech-marquee-row")
+      .first()
+      .locator("ul.animate-marquee")
+      .first();
+    const durationStr = await track.evaluate((el) => getComputedStyle(el).animationDuration);
+    // Global `prefers-reduced-motion: reduce` rule in globals.css sets
+    // `animation-duration: 0.01ms !important`. Browsers may normalise that
+    // value as `0.01ms`, `1e-05s`, or `0s` — they're all effectively zero.
+    // We accept anything below 1ms.
+    const m = durationStr.match(/^([0-9eE.+-]+)(ms|s)$/);
+    expect(m, `unexpected animation-duration format: ${durationStr}`).not.toBeNull();
+    const value = parseFloat(m![1]);
+    const unitMs = m![2] === "s" ? 1000 : 1;
+    expect(value * unitMs).toBeLessThan(1);
+    await context.close();
+  });
+});
+
+test.describe("Badge text-extraction — bug regression", () => {
+  test("homepage tech stack: innerText yields separated skill tokens", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en");
+    const section = page.locator('[data-section="tech-stack"]');
+    const text = await section.innerText();
+    expect(text).toMatch(/\bPython\b/);
+    expect(text).toMatch(/\bTypeScript\b/);
+    expect(text).toMatch(/\bJavaScript\b/);
+    expect(text).toMatch(/\bJava\b/);
+    expect(text).not.toMatch(/PythonTypeScript(?!\s)/);
+    expect(text).not.toMatch(/TypeScriptJavaScript(?!\s)/);
+    expect(text).not.toMatch(/JavaScriptJava(?!\s)/);
+  });
+
+  test("CV page skills: innerText yields separated skill tokens", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/en/cv");
+    const skillsSection = page.locator('section:has(h2:has-text("Skills"))').first();
+    const text = await skillsSection.innerText();
+    expect(text).toMatch(/\bPython\b/);
+    expect(text).not.toMatch(/PythonTypeScript(?!\s)/);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,14 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom does not implement ResizeObserver. Provide a minimal stub so that
+// components which observe layout size (e.g. TechMarquee) can mount in unit
+// tests without throwing.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+}

--- a/tests/unit/tech-marquee.test.tsx
+++ b/tests/unit/tech-marquee.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import { TechMarquee } from "@/components/shared/tech-marquee";
+import type { TechCategory } from "@/content/tech-stack";
+
+const languagesGroup: TechCategory = {
+  label: "Programming Languages",
+  category: "language",
+  skills: [
+    { name: "Python", category: "language" },
+    { name: "TypeScript", category: "language" },
+    { name: "JavaScript", category: "language" },
+    { name: "Java", category: "language" },
+  ],
+};
+
+describe("TechMarquee — SSR / initial render", () => {
+  // No layout in these tests: getBoundingClientRect returns 0s in jsdom, so
+  // the client-side measurement step bails and we observe the SSR fallback
+  // (1 sub-row containing every skill).
+
+  it("renders the category label tied to the section via aria-labelledby", () => {
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    const section = container.querySelector("section");
+    expect(section).not.toBeNull();
+    const labelId = section?.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    const label = container.querySelector(`#${labelId}`);
+    expect(label?.textContent).toBe("Programming Languages");
+  });
+
+  it("renders every skill in the primary (non-aria-hidden) track", () => {
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    const primaryTrack = container.querySelector("ul:not([aria-hidden])");
+    expect(primaryTrack).not.toBeNull();
+    const items = primaryTrack!.querySelectorAll("li");
+    expect(items).toHaveLength(4);
+    const names = Array.from(items).map((li) => li.textContent);
+    expect(names).toEqual(["Python", "TypeScript", "JavaScript", "Java"]);
+  });
+
+  it("renders duplicate tracks marked aria-hidden for seamless loop", () => {
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    const dupes = container.querySelectorAll('ul[aria-hidden="true"]');
+    expect(dupes.length).toBeGreaterThanOrEqual(1);
+    dupes.forEach((ul) => {
+      expect(ul.querySelectorAll("li")).toHaveLength(4);
+    });
+  });
+
+  it("BUG REGRESSION: primary <ul> has one <li> per skill with token boundaries", () => {
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    const primaryTrack = container.querySelector("ul:not([aria-hidden])") as HTMLUListElement;
+    expect(primaryTrack).not.toBeNull();
+    const liTexts = Array.from(primaryTrack.querySelectorAll("li")).map(
+      (li) => li.textContent?.trim(),
+    );
+    expect(liTexts).toContain("Python");
+    expect(liTexts).toContain("TypeScript");
+    expect(liTexts).toContain("JavaScript");
+    expect(liTexts).toContain("Java");
+    liTexts.forEach((t) => {
+      expect(t).not.toMatch(/PythonTypeScript/);
+    });
+  });
+
+  it("applies [animation-direction:reverse] on odd-index categories (LTR)", () => {
+    const { container } = render(<TechMarquee group={languagesGroup} index={1} />);
+    const primary = container.querySelector("ul:not([aria-hidden])")!;
+    expect(primary.className).toContain("[animation-direction:reverse]");
+  });
+
+  it("does NOT apply reverse on even-index categories (LTR)", () => {
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    const primary = container.querySelector("ul:not([aria-hidden])")!;
+    expect(primary.className).not.toContain("[animation-direction:reverse]");
+  });
+
+  it("inverts the direction pattern when isRtl is true", () => {
+    const { container: ltr } = render(
+      <TechMarquee group={languagesGroup} index={0} isRtl={false} />,
+    );
+    const { container: rtl } = render(
+      <TechMarquee group={languagesGroup} index={0} isRtl={true} />,
+    );
+    const ltrTrack = ltr.querySelector("ul:not([aria-hidden])")!;
+    const rtlTrack = rtl.querySelector("ul:not([aria-hidden])")!;
+    expect(ltrTrack.className).not.toContain("[animation-direction:reverse]");
+    expect(rtlTrack.className).toContain("[animation-direction:reverse]");
+  });
+
+  it("sets --duration proportional to skill count on the sub-row container", () => {
+    const shortGroup: TechCategory = {
+      ...languagesGroup,
+      skills: languagesGroup.skills.slice(0, 2),
+    };
+    const longGroup: TechCategory = {
+      ...languagesGroup,
+      skills: Array.from({ length: 20 }, (_, i) => ({
+        name: `Skill${i}`,
+        category: "language" as const,
+      })),
+    };
+    const { container: shortC } = render(<TechMarquee group={shortGroup} index={0} />);
+    const { container: longC } = render(<TechMarquee group={longGroup} index={0} />);
+    const shortDur = shortC
+      .querySelector<HTMLDivElement>("[data-subrow]")!
+      .style.getPropertyValue("--duration");
+    const longDur = longC
+      .querySelector<HTMLDivElement>("[data-subrow]")!
+      .style.getPropertyValue("--duration");
+    expect(shortDur).toBe("30s");
+    expect(parseInt(longDur)).toBeGreaterThanOrEqual(parseInt(shortDur));
+  });
+
+  it("every track ul has the pause-on-hover class", () => {
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    const tracks = container.querySelectorAll("ul.animate-marquee");
+    expect(tracks.length).toBeGreaterThanOrEqual(2);
+    tracks.forEach((track) => {
+      expect(track.className).toContain("group-hover:[animation-play-state:paused]");
+    });
+  });
+});
+
+describe("TechMarquee — dynamic row splitting", () => {
+  // These tests mock getBoundingClientRect (per <li>) and container.clientWidth
+  // so the measurement step sees realistic widths and packs accordingly.
+
+  let getBoundingSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Each <li> is 100px wide. GAP_PX = 8 → each item costs 108px.
+    getBoundingSpy = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: Element) {
+        if (this.tagName === "LI") {
+          return {
+            width: 100,
+            height: 20,
+            top: 0,
+            left: 0,
+            right: 100,
+            bottom: 20,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          } as DOMRect;
+        }
+        return {
+          width: 0,
+          height: 0,
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRect;
+      });
+  });
+
+  afterEach(() => {
+    getBoundingSpy.mockRestore();
+  });
+
+  const mockContainerWidth = (width: number) => {
+    // Force <section> clientWidth to the given value.
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        if (this.tagName === "SECTION") return width;
+        return 0;
+      },
+    });
+  };
+
+  it("keeps a single sub-row when the natural row width fits the container", async () => {
+    // 4 skills * 108px = 432px total. Container 800px → fits in one row.
+    mockContainerWidth(800);
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    // Allow useLayoutEffect to run.
+    await act(async () => {});
+    const subRows = container.querySelectorAll("[data-subrow]");
+    expect(subRows.length).toBe(1);
+    const primary = container.querySelector("ul:not([aria-hidden])")!;
+    expect(primary.querySelectorAll("li")).toHaveLength(4);
+  });
+
+  it("splits into multiple sub-rows when the natural row width exceeds the container", async () => {
+    // 4 skills * 108px = 432px. Container 200px → must split.
+    // maxRow = 200 - 24 = 176. With cost 108 each: row 0 = [skill 0] (108),
+    // next skill (216>176) → new row. Result: 4 sub-rows of 1 item each.
+    mockContainerWidth(200);
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    await act(async () => {});
+    const subRows = container.querySelectorAll("[data-subrow]");
+    expect(subRows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("sub-rows within a category alternate scroll direction (zigzag)", async () => {
+    // Force multiple sub-rows.
+    mockContainerWidth(200);
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    await act(async () => {});
+    const primaries = container.querySelectorAll("ul:not([aria-hidden])");
+    expect(primaries.length).toBeGreaterThanOrEqual(2);
+    const rev0 = primaries[0].className.includes("[animation-direction:reverse]");
+    const rev1 = primaries[1].className.includes("[animation-direction:reverse]");
+    expect(rev0).not.toBe(rev1);
+  });
+
+  it("every skill appears exactly once across primary sub-rows (no loss, no duplication)", async () => {
+    mockContainerWidth(250); // forces a split
+    const { container } = render(<TechMarquee group={languagesGroup} index={0} />);
+    await act(async () => {});
+    const primaries = container.querySelectorAll("ul:not([aria-hidden])");
+    const allNames: string[] = [];
+    primaries.forEach((ul) => {
+      ul.querySelectorAll("li").forEach((li) => {
+        allNames.push(li.textContent?.trim() ?? "");
+      });
+    });
+    expect(allNames.sort()).toEqual(
+      ["Java", "JavaScript", "Python", "TypeScript"].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the static tech-stack grid in the About section with a horizontally-scrolling marquee, and fixes a subtle bug in the CV where skill chips rendered as inline-wrapped `<div>`s caused crawlers and LLM scrapers to read `"Python"`, `"TypeScript"`, `"JavaScript"` as the concatenated blob `"PythonTypeScriptJavaScript"`.

## Behaviour

### Tech stack marquee
- One row per category with colour-coded badges.
- **Dynamic row-splitting**: on mount, `useLayoutEffect` + `ResizeObserver` measure the container and each badge's natural width, then greedy-pack skills into as many sub-rows as needed so **every badge is visible on initial paint** at any viewport. No more "waiting for AI/ML skills to scroll in".
- **Category-wide pause**: hovering any sub-row (desktop) or touch-and-holding it (mobile) pauses every sub-row in that category. Other categories keep scrolling.
- Sub-rows alternate scroll direction per category (zigzag), RTL-aware.
- Respects `prefers-reduced-motion: reduce`.
- SSR-safe: renders canonical 1-row fallback for crawlers and no-JS.

### CV skill chips
- `cv-skills.tsx` and `themes/portfolio-gallery.tsx` now render skill lists as proper `<ul>`/`<li>`. `innerText` now exposes line breaks between skills, so every extraction pipeline (crawlers, LLMs, copy-paste, screen readers) sees each skill as a distinct token.

## Tests

- 13 new unit tests (`tests/unit/tech-marquee.test.tsx`): SSR shape, dynamic split with mocked `getBoundingClientRect`, RTL, duration scaling, category-wide pause class, ul/li regression guard.
- 10 new E2E tests (`tests/e2e/tech-stack.spec.ts`): sub-row counts at 1440px, direction alternation, hover pause, touch-hold pause (synthetic `touchstart`/`touchend`), reduced-motion, skill-text extraction.
- `tests/setup.ts`: `ResizeObserver` stub for jsdom.

Local: `make lint`, `make test` (51/51), `make build`, and `pnpm playwright test --project=chromium` on the new spec (10/10) all green.

## Screenshots

https://reebal-sami.com once merged — auto-deploy via `.github/workflows/deploy.yml`.

## Notes for reviewer

- `src/components/ui/marquee.tsx` is the magicui primitive from the shadcn CLI install. It's not imported anywhere today — kept for potential future reuse, same convention as other `components/ui/*` primitives.
- No dependency changes. Only CSS keyframes from `@theme` and React touch handlers.
- No changes to `tech-stack.ts` data, CV data, or any other section.
