### PR TITLE
ci: increase deploy timeout 25→60min

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
   deploy:
     name: Build & Deploy to AWS
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 60
     environment:
       name: production
       url: https://reebal-sami.com


### PR DESCRIPTION
## Summary
- The CDK + CloudFront invalidation deploy consistently hits the 25-minute job timeout
- PR #51 and PR #50 both had their deploys cancelled/fail due to this limit
- Increased to 60 minutes to give the deploy room to complete

## Test plan
- [ ] Deploy job completes within 60 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)