### PR TITLE
fix(infra): bump BucketDeployment Lambda memory 128→512 MB

### DIFF
--- a/infra/lib/portfolio-stack.ts
+++ b/infra/lib/portfolio-stack.ts
@@ -255,11 +255,18 @@ export class PortfolioStack extends cdk.Stack {
     });
 
     // ─── S3 Deployment (static assets) ────────────────────────────────
+    // memoryLimit: 512 — the CDK-provisioned deployment Lambda was maxing
+    // the 128 MB default (127-128/128 MB on every deploy since stack creation).
+    // PR #50's 3.7 MB asset addition crossed the ceiling → Runtime.OutOfMemory
+    // on 3 CFN retries → stack rolled back, blocking all prod deploys. See #53.
+    // 512 MB gives 4× headroom and more CPU (deploys ~60s vs ~100s);
+    // cost delta ~$0.0003 per deploy.
     new s3deploy.BucketDeployment(this, 'DeployStaticAssets', {
       sources: [s3deploy.Source.asset(staticDir)],
       destinationBucket: this.siteBucket,
       distribution: this.distribution,
       distributionPaths: ['/_next/static/*', '/images/*'],
+      memoryLimit: 512,
     });
 
     // ─── Route 53 DNS Records ─────────────────────────────────────────


### PR DESCRIPTION
## Why

Every deploy since PR #50 has failed (runs [24775586478](https://github.com/ReebalSami/portfolio-website/actions/runs/24775586478), [24790093629](https://github.com/ReebalSami/portfolio-website/actions/runs/24790093629), [24791775409](https://github.com/ReebalSami/portfolio-website/actions/runs/24791775409)), leaving production stuck on PR #44. Root cause is the CDK-provisioned `BucketDeployment` Lambda maxing its **128 MB default memory** — confirmed via CloudWatch `Runtime.OutOfMemory` reports across 3× CFN retries per deploy. Full analysis in #53.

## What

Set `memoryLimit: 512` on `s3deploy.BucketDeployment` in `infra/lib/portfolio-stack.ts`. 4× headroom and more CPU (Lambda CPU scales with memory), so deploys also run ~40% faster.

## Verification

- ✅ `npm test` — 6/6 infra tests pass
- ✅ `cdk synth PortfolioStack --context stage=prod` — emits new Lambda `CustomCDKBucketDeployment…512MiB…` at `Memory=512`, `Timeout=900`
- ✅ CDK auto-cleans the old 128 MB Lambda (singleton per memory config)

## Cost

~$0.0003 per deploy delta. Invisible.

Closes #53
